### PR TITLE
QS: Show # of clients connected to hotspot

### DIFF
--- a/core/java/android/net/ConnectivityManager.java
+++ b/core/java/android/net/ConnectivityManager.java
@@ -26,6 +26,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.wifi.WifiDevice;
 import android.os.Binder;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -58,6 +59,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.InetAddress;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -295,6 +297,15 @@ public class ConnectivityManager {
     @SdkConstant(SdkConstantType.BROADCAST_INTENT_ACTION)
     public static final String ACTION_TETHER_STATE_CHANGED =
             "android.net.conn.TETHER_STATE_CHANGED";
+
+    /**
+     * Broadcast intent action indicating that a Station is connected
+     * or disconnected.
+     *
+     * @hide
+     */
+    public static final String TETHER_CONNECT_STATE_CHANGED =
+            "codeaurora.net.conn.TETHER_CONNECT_STATE_CHANGED";
 
     /**
      * @hide
@@ -1995,6 +2006,20 @@ public class ConnectivityManager {
             return mService.untether(iface);
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
+        }
+    }
+
+    /**
+     * Get the list of Stations connected to Hotspot.
+     *
+     * @return a list of {@link WifiDevice} objects.
+     * {@hide}
+     */
+    public List<WifiDevice> getTetherConnectedSta() {
+        try {
+            return mService.getTetherConnectedSta();
+        } catch (RemoteException e) {
+            return null;
         }
     }
 

--- a/core/java/android/net/IConnectivityManager.aidl
+++ b/core/java/android/net/IConnectivityManager.aidl
@@ -30,11 +30,14 @@ import android.os.IBinder;
 import android.os.Messenger;
 import android.os.ParcelFileDescriptor;
 import android.os.ResultReceiver;
+import android.net.wifi.WifiDevice;
 
 import com.android.internal.net.LegacyVpnInfo;
 import com.android.internal.net.VpnConfig;
 import com.android.internal.net.VpnInfo;
 import com.android.internal.net.VpnProfile;
+
+import java.util.List;
 
 /**
  * Interface that answers queries about, and allows changing, the
@@ -96,6 +99,8 @@ interface IConnectivityManager
     String[] getTetherableBluetoothRegexs();
 
     int setUsbTethering(boolean enable);
+
+    List<WifiDevice> getTetherConnectedSta();
 
     void reportInetCondition(int networkType, int percentage);
 

--- a/core/java/android/net/INetworkManagementEventObserver.aidl
+++ b/core/java/android/net/INetworkManagementEventObserver.aidl
@@ -92,6 +92,13 @@ interface INetworkManagementEventObserver {
     void interfaceClassDataActivityChanged(String label, boolean active, long tsNanos);
 
     /**
+     * Message is received from network interface.
+     *
+     * @param message The message
+     */
+    void interfaceMessageRecevied(String message);
+
+    /**
      * Information about available DNS servers has been received.
      *
      * @param iface The interface on which the information was received.

--- a/core/java/com/android/server/net/BaseNetworkObserver.java
+++ b/core/java/com/android/server/net/BaseNetworkObserver.java
@@ -63,6 +63,11 @@ public class BaseNetworkObserver extends INetworkManagementEventObserver.Stub {
     }
 
     @Override
+    public void interfaceMessageRecevied(String message) {
+        // default no-op
+    }
+
+    @Override
     public void limitReached(String limitName, String iface) {
         // default no-op
     }

--- a/core/res/res/values/bools.xml
+++ b/core/res/res/values/bools.xml
@@ -24,4 +24,7 @@
     <bool name="show_ongoing_ime_switcher">true</bool>
     <bool name="action_bar_expanded_action_views_exclusive">true</bool>
     <bool name="target_honeycomb_needs_options_menu">true</bool>
+
+    <!-- Whether to enable softap extention feature -->
+    <bool name="config_softap_extention">true</bool>
 </resources>

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -79,4 +79,7 @@
     <java-symbol type="bool" name="config_forceAnalogCarDock" />
     <java-symbol type="bool" name="config_forceAnalogDeskDock" />
 
+    <!-- config softap extention feature -->
+    <java-symbol type="bool" name="config_softap_extention" />
+
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2785,4 +2785,6 @@
 
   <java-symbol type="drawable" name="ic_restart" />
 
+  <!-- config softap extention feature -->
+  <java-symbol type="bool" name="config_softap_extention" />
 </resources>

--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -102,4 +102,11 @@
     <!-- NavBar Tuner -->
     <string name="menu_ime_always_show">Menu / Keyboard Switcher (always show)</string>
     <string name="search">Search</string>
+
+    <!-- Wi-Fi hotspot label when enabled -->
+    <plurals name="wifi_hotspot_connected_clients_label">
+        <item quantity="one">%1$d client</item>
+        <item quantity="other">%1$d clients</item>
+    </plurals>
+
 </resources>

--- a/services/core/java/com/android/server/ConnectivityService.java
+++ b/services/core/java/com/android/server/ConnectivityService.java
@@ -78,6 +78,7 @@ import android.net.metrics.DefaultNetworkEvent;
 import android.net.metrics.IpConnectivityLog;
 import android.net.metrics.NetworkEvent;
 import android.net.util.AvoidBadWifiTracker;
+import android.net.wifi.WifiDevice;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
@@ -2995,6 +2996,14 @@ public class ConnectivityService extends IConnectivityManager.Stub
                     break;
                 }
             }
+        }
+    }
+
+    public List<WifiDevice> getTetherConnectedSta() {
+        if (isTetheringSupported()) {
+            return mTethering.getTetherConnectedSta();
+        } else {
+             return null;
         }
     }
 

--- a/services/core/java/com/android/server/connectivity/Tethering.java
+++ b/services/core/java/com/android/server/connectivity/Tethering.java
@@ -31,8 +31,6 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.hardware.usb.UsbManager;
-import android.net.ConnectivityManager;
-import android.net.ConnectivityManager.NetworkCallback;
 import android.net.INetworkStatsService;
 import android.net.LinkProperties;
 import android.net.Network;
@@ -42,6 +40,9 @@ import android.net.NetworkRequest;
 import android.net.NetworkState;
 import android.net.NetworkUtils;
 import android.net.RouteInfo;
+import android.net.ConnectivityManager;
+import android.net.ConnectivityManager.NetworkCallback;
+import android.net.wifi.WifiDevice;
 import android.net.wifi.WifiManager;
 import android.os.Binder;
 import android.os.Bundle;
@@ -51,7 +52,6 @@ import android.os.Message;
 import android.os.Parcel;
 import android.os.ResultReceiver;
 import android.os.SystemProperties;
-import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.provider.Settings;
 import android.telephony.CarrierConfigManager;
@@ -60,6 +60,7 @@ import android.text.TextUtils;
 import android.util.ArrayMap;
 import android.util.Log;
 import android.util.SparseArray;
+import com.android.internal.util.IState;
 
 import com.android.internal.telephony.IccCardConstants;
 import com.android.internal.telephony.TelephonyIntents;
@@ -75,6 +76,9 @@ import com.android.server.connectivity.tethering.IPv6TetheringCoordinator;
 import com.android.server.connectivity.tethering.TetherInterfaceStateMachine;
 import com.android.server.net.BaseNetworkObserver;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.net.Inet4Address;
@@ -85,6 +89,18 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+
+
+import static android.net.wifi.WifiManager.WIFI_AP_STATE_CHANGED_ACTION;
+import static android.net.wifi.WifiManager.WIFI_AP_STATE_DISABLED;
+import static android.net.wifi.WifiManager.WIFI_AP_STATE_ENABLED;
 
 
 /**
@@ -175,8 +191,20 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
     private boolean mUsbTetherRequested; // true if USB tethering should be started
                                          // when RNDIS is enabled
 
+
     // True iff WiFi tethering should be started when soft AP is ready.
     private boolean mWifiTetherRequested;
+
+    // Once STA established connection to hostapd, it will be added
+    // to mL2ConnectedDeviceMap. Then after deviceinfo update from dnsmasq,
+    // it will be added to
+    private HashMap<String, WifiDevice> mL2ConnectedDeviceMap = new HashMap<String, WifiDevice>();
+    private HashMap<String, WifiDevice> mConnectedDeviceMap = new HashMap<String, WifiDevice>();
+    private static final String dhcpLocation = "/data/misc/dhcp/dnsmasq.leases";
+
+    // Device name polling interval(ms) and max times
+    private static final int DNSMASQ_POLLING_INTERVAL = 1000;
+    private static final int DNSMASQ_POLLING_MAX_TIMES = 10;
 
     public Tethering(Context context, INetworkManagementService nmService,
             INetworkStatsService statsService) {
@@ -201,6 +229,7 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
         filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
         filter.addAction(WifiManager.WIFI_AP_STATE_CHANGED_ACTION);
         filter.addAction(Intent.ACTION_CONFIGURATION_CHANGED);
+        filter.addAction(WIFI_AP_STATE_CHANGED_ACTION);
         mContext.registerReceiver(mStateReceiver, filter);
 
         filter = new IntentFilter();
@@ -268,7 +297,8 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
         // See NetlinkHandler.cpp:71.
         if (VDBG) Log.d(TAG, "interfaceStatusChanged " + iface + ", " + up);
         WifiManager mWifiManager =
-           (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+                (WifiManager) mContext.getSystemService(Context.WIFI_SERVICE);
+        WifiDevice device = new WifiDevice(iface);
         synchronized (mPublicSync) {
             int interfaceType = ifaceNameToType(iface);
             if (interfaceType == ConnectivityManager.TETHERING_INVALID) {
@@ -279,18 +309,14 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
             if (up) {
                 if (tetherState == null) {
                     trackNewTetherableInterface(iface, interfaceType);
+                    mConnectedDeviceMap.put(device.deviceAddress, device);
                 }
             } else {
                 if (interfaceType == ConnectivityManager.TETHERING_BLUETOOTH) {
                     tetherState.mStateMachine.sendMessage(
                             TetherInterfaceStateMachine.CMD_INTERFACE_DOWN);
                     mTetherStates.remove(iface);
-                } else {
-                    // Ignore usb0 down after enabling RNDIS.
-                    // We will handle disconnect in interfaceRemoved.
-                    // Similarly, ignore interface down for WiFi.  We monitor WiFi AP status
-                    // through the WifiManager.WIFI_AP_STATE_CHANGED_ACTION intent.
-                    if (VDBG) Log.d(TAG, "ignore interface down for " + iface);
+                    mConnectedDeviceMap.remove(iface);
                 }
             }
         }
@@ -848,6 +874,15 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
                 }
             } else if (action.equals(Intent.ACTION_CONFIGURATION_CHANGED)) {
                 updateConfiguration();
+            } else if(action.equals(WIFI_AP_STATE_CHANGED_ACTION)){
+                int wifiApState = intent.getIntExtra("wifi_state", WIFI_AP_STATE_DISABLED);
+                if (DBG) Log.d(TAG, "WIFI_AP_STATE_CHANGED: wifiApState="  + wifiApState);
+                if(wifiApState == WIFI_AP_STATE_ENABLED ||
+                        wifiApState == WIFI_AP_STATE_DISABLED) {
+                    mConnectedDeviceMap.clear();
+                    mL2ConnectedDeviceMap.clear();
+
+                }
             }
         }
     }
@@ -1001,6 +1036,168 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
         }
         return list.toArray(new String[list.size()]);
     }
+
+    public List<WifiDevice> getTetherConnectedSta() {
+        Iterator it;
+        List<WifiDevice> TetherConnectedStaList = new ArrayList<WifiDevice>();
+
+        if (mContext.getResources().getBoolean(com.android.internal.R.bool.config_softap_extention)) {
+            it = mConnectedDeviceMap.keySet().iterator();
+            while(it.hasNext()) {
+                String key = (String)it.next();
+                WifiDevice device = mConnectedDeviceMap.get(key);
+                if (VDBG) {
+                    Log.d(TAG, "getTetherConnectedSta: addr=" + key + " name=" + device.deviceName);
+                }
+                TetherConnectedStaList.add(device);
+            }
+        }
+
+        return TetherConnectedStaList;
+    }
+
+    private void sendTetherConnectStateChangedBroadcast() {
+        if (!getConnectivityManager().isTetheringSupported()) return;
+
+        Intent broadcast = new Intent(ConnectivityManager.TETHER_CONNECT_STATE_CHANGED);
+        broadcast.addFlags(Intent.FLAG_RECEIVER_REPLACE_PENDING |
+                Intent.FLAG_RECEIVER_REGISTERED_ONLY_BEFORE_BOOT);
+
+        mContext.sendStickyBroadcastAsUser(broadcast, UserHandle.ALL);
+    }
+
+    private boolean readDeviceInfoFromDnsmasq(WifiDevice device) {
+        boolean result = false;
+        FileInputStream fstream = null;
+        String line;
+
+        try {
+            fstream = new FileInputStream(dhcpLocation);
+            DataInputStream in = new DataInputStream(fstream);
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+
+            while ((null != (line = br.readLine())) && (line.length() != 0)) {
+                String[] fields = line.split(" ");
+
+                // 949295 00:0a:f5:6a:bf:70 192.168.43.32 android-93de88df9ec61bac *
+                if (fields.length > 3) {
+                    String addr = fields[1];
+                    String name = fields[3];
+
+                    if (addr.equals(device.deviceAddress)) {
+                        device.deviceName = name;
+                        result = true;
+                        break;
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            Log.e(TAG, "readDeviceNameFromDnsmasq: " + ex);
+        } finally {
+            if (fstream != null) {
+                try {
+                    fstream.close();
+                } catch (IOException ex) {}
+            }
+        }
+
+        return result;
+    }
+
+    /*
+    * DnsmasqThread is used to read the Device info from dnsmasq.
+    */
+    private static class DnsmasqThread extends Thread {
+        private final Tethering mTethering;
+        private int mInterval;
+        private int mMaxTimes;
+        private WifiDevice mDevice;
+
+        public DnsmasqThread(Tethering tethering, WifiDevice device,
+                             int interval, int maxTimes) {
+            super("Tethering");
+            mTethering = tethering;
+            mInterval = interval;
+            mMaxTimes = maxTimes;
+            mDevice = device;
+        }
+
+        public void run() {
+            boolean result = false;
+
+            try {
+                while (mMaxTimes > 0) {
+                    result = mTethering.readDeviceInfoFromDnsmasq(mDevice);
+                    if (result) {
+                        if (DBG) Log.d(TAG, "Successfully poll device info for " + mDevice.deviceAddress);
+                        break;
+                    }
+
+                    mMaxTimes --;
+                    Thread.sleep(mInterval);
+                }
+            } catch (Exception ex) {
+                result = false;
+                Log.e(TAG, "Pulling " + mDevice.deviceAddress +  "error" + ex);
+            }
+
+            if (!result) {
+                if (DBG) Log.d(TAG, "Pulling timeout, suppose STA uses static ip " + mDevice.deviceAddress);
+            }
+
+            // When STA uses static ip, device info will be unavaiable from dnsmasq,
+            // thus no matter the result is success or failure, we will broadcast the event.
+            // But if the device is not in L2 connected state, it means the hostapd connection is
+            // disconnected before dnsmasq get device info, so in this case, don't broadcast
+            // connection event.
+            WifiDevice other = mTethering.mL2ConnectedDeviceMap.get(mDevice.deviceAddress);
+            if (other != null && other.deviceState == WifiDevice.CONNECTED) {
+                mTethering.mConnectedDeviceMap.put(mDevice.deviceAddress, mDevice);
+                mTethering.sendTetherConnectStateChangedBroadcast();
+            } else {
+                if (DBG) Log.d(TAG, "Device " + mDevice.deviceAddress + "already disconnected, ignoring");
+            }
+        }
+    }
+
+    public void interfaceMessageRecevied(String message) {
+        // if softap extension feature not enabled, do nothing
+        if (!mContext.getResources().getBoolean(com.android.internal.R.bool.config_softap_extention)) {
+            return;
+        }
+
+        if (DBG) Log.d(TAG, "interfaceMessageRecevied: message=" + message);
+
+        try {
+            WifiDevice device = new WifiDevice(message);
+
+            if (device.deviceState == WifiDevice.CONNECTED) {
+                mL2ConnectedDeviceMap.put(device.deviceAddress, device);
+
+                // When hostapd reported STA-connection event, it is possible that device
+                // info can't fetched from dnsmasq, then we start a thread to poll the
+                // device info, the thread will exit after device info avaiable.
+                // For static ip case, dnsmasq don't hold the device info, thus thread
+                // will exit after a timeout.
+                if (readDeviceInfoFromDnsmasq(device)) {
+                    mConnectedDeviceMap.put(device.deviceAddress, device);
+                    sendTetherConnectStateChangedBroadcast();
+                } else {
+                    if (DBG) Log.d(TAG, "Starting poll device info for " + device.deviceAddress);
+                    new DnsmasqThread(this, device,
+                            DNSMASQ_POLLING_INTERVAL, DNSMASQ_POLLING_MAX_TIMES).start();
+                }
+                //cancelInactivityTimeout();
+            } else if (device.deviceState == WifiDevice.DISCONNECTED) {
+                mL2ConnectedDeviceMap.remove(device.deviceAddress);
+                mConnectedDeviceMap.remove(device.deviceAddress);
+                sendTetherConnectStateChangedBroadcast();
+            }
+        } catch (IllegalArgumentException ex) {
+            Log.e(TAG, "WifiDevice IllegalArgument: " + ex);
+        }
+    }
+
 
     public String[] getTetherableIfaces() {
         ArrayList<String> list = new ArrayList<String>();

--- a/wifi/java/android/net/wifi/WifiDevice.aidl
+++ b/wifi/java/android/net/wifi/WifiDevice.aidl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.net.wifi;
+
+parcelable WifiDevice;

--- a/wifi/java/android/net/wifi/WifiDevice.java
+++ b/wifi/java/android/net/wifi/WifiDevice.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package android.net.wifi;
+
+import android.os.Parcelable;
+import android.os.Parcel;
+
+/**
+ * Describes information about a detected Wi-Fi STA.
+ * {@hide}
+ */
+public class WifiDevice implements Parcelable {
+    /**
+     * The device MAC address is the unique id of a Wi-Fi STA
+     */
+    public String deviceAddress = "";
+
+    /**
+     * The device name is a readable string of a Wi-Fi STA
+     */
+    public String deviceName = "";
+
+    /**
+     * The device state is the state of a Wi-Fi STA
+     */
+    public int deviceState = 0;
+
+    /**
+     * These definitions are for deviceState
+     */
+    public static final int DISCONNECTED = 0;
+    public static final int CONNECTED    = 1;
+    public static final int BLACKLISTED  = 2;
+
+    private static final String AP_STA_CONNECTED_STR   = "AP-STA-CONNECTED";
+    private static final String AP_STA_DISCONNECTED_STR   = "AP-STA-DISCONNECTED";
+
+    /** {@hide} */
+    public WifiDevice() {}
+
+    /**
+     * @param string formats supported include
+     *
+     *  AP-STA-CONNECTED 42:fc:89:a8:96:09
+     *  AP-STA-DISCONNECTED 42:fc:89:a8:96:09
+     *
+     *  Note: The events formats can be looked up in the hostapd code
+     * @hide
+     */
+    public WifiDevice(String dataString) throws IllegalArgumentException {
+        String[] tokens = dataString.split(" ");
+
+        if (tokens.length < 2) {
+            throw new IllegalArgumentException();
+        }
+
+        if (tokens[0].indexOf(AP_STA_CONNECTED_STR) != -1) {
+            deviceState = CONNECTED;
+        } else if (tokens[0].indexOf(AP_STA_DISCONNECTED_STR) != -1) {
+            deviceState = DISCONNECTED;
+        } else {
+            throw new IllegalArgumentException();
+        }
+
+        deviceAddress = tokens[1];
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof WifiDevice)) {
+            return false;
+        }
+
+        WifiDevice other = (WifiDevice) obj;
+
+        if (deviceAddress == null) {
+            return (other.deviceAddress == null);
+        } else {
+            return deviceAddress.equals(other.deviceAddress);
+        }
+    }
+
+    /** Implement the Parcelable interface {@hide} */
+    public int describeContents() {
+        return 0;
+    }
+
+    /** Implement the Parcelable interface {@hide} */
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(deviceAddress);
+        dest.writeString(deviceName);
+        dest.writeInt(deviceState);
+    }
+
+    /** Implement the Parcelable interface {@hide} */
+    public static final Creator<WifiDevice> CREATOR =
+            new Creator<WifiDevice>() {
+                public WifiDevice createFromParcel(Parcel in) {
+                    WifiDevice device = new WifiDevice();
+                    device.deviceAddress = in.readString();
+                    device.deviceName = in.readString();
+                    device.deviceState = in.readInt();
+                    return device;
+                }
+
+                public WifiDevice[] newArray(int size) {
+                    return new WifiDevice[size];
+                }
+            };
+}


### PR DESCRIPTION
Since we no longer post a notification showing that the wifi hotspot
is on and the # of connected clients, we now show the # of clients
connected in the label of the hotspot QS tile.

Change-Id: I9ed37b96db9b5b4320a7260524f69733ea70d030

HotSpot: Store # of connected clients in receiver

Get the number of connected clients in onReceive and cache the value
to be used in handleUpdateState.

Change-Id: I011a13e186c1fa9976df58a4ad1603e6c0cd6bbb